### PR TITLE
HANDLE_MULTIPLE_PROTECTED_SERVICES If multiple pids come back when check...

### DIFF
--- a/servicemanager/smprocess.py
+++ b/servicemanager/smprocess.py
@@ -59,7 +59,7 @@ def _is_pid_in_list(pid, command):
     return False
 
 def _is_init_process(pid):
-    command = "ps -eo ppid,pid,etime,rss,args | grep 'init --user' | grep -v 'grep init --user' | awk '{print $2 }'"
+    command = "ps -eo ppid,pid,etime,rss,args | grep 'init --user' | grep -v 'grep init --user' | grep -v indicator | awk '{print $2 }'"
     return _is_pid_in_list(pid, command)
 
 


### PR DESCRIPTION
Before we stop a service we check to see if it is a "special service" first to ensure we are not stopping the wrong thing

We had an issue where if multiple instances of some of these were running (seemed to only be happening on ubuntu) we were getting an error because instead of a single pid coming back "123456" we we getting "123456\n876543". We now handle this happening and iterate over each, checking the pid against each in the list
