### PR TITLE
ASYNC_STATUS Modified sm to call healthcheck asynchronously

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='servicemanager',
       author='vaughansharman',
       license='Apache Licence 2.0',
       packages=['servicemanager', 'servicemanager.actions', 'servicemanager.server', 'servicemanager.service', 'servicemanager.thirdparty'],
-      install_requires=['requests==2.2.1','pymongo==2.6.3','bottle==0.12.4','pytest==2.5.2','argcomplete==0.8.1'],
+      install_requires=['requests==2.2.1','pymongo==2.6.3','bottle==0.12.4','pytest==2.5.2','argcomplete==0.8.1', 'futures==2.2.0'],
       scripts=['bin/sm', 'bin/smserver'],
       zip_safe=False)


### PR DESCRIPTION
This is intended to start a conversation, there may be a few more things required before we should merge this, but this change makes the status command collect info on running services asynchronously... This when run locally with one profile running decreased the runtime of status from 4 seconds to 2 which is quite a good start.

If you are interested have a look and let me know your thoughts 