### PR TITLE
Enable retrieving artifacts from Bintray

### DIFF
--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -92,7 +92,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
             binaryConfig = self.service_data["binary"]
             artifactRepo = SmArtifactRepoFactory.get_repository(self.context, self.service_name, binaryConfig)
             if not self.version:
-                self.version = artifactRepo.find_latest_version(self.run_from, binaryConfig["artifact"])
+                self.version = artifactRepo.find_latest_version(self.run_from, binaryConfig["artifact"], binaryConfig["groupId"])
             artifactRepo.download_jar_if_necessary(self.run_from, self.version)
 
         unzip_dir = self._unpack_play_application(SmArtifactRepoFactory.get_play_app_extension(binaryConfig))

--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import zipfile
+import tarfile
 import stat
 import copy
 import types
@@ -13,7 +14,7 @@ from servicemanager.subprocess import Popen
 from ..service.smservice import SmMicroServiceStarter
 from smjvmservice import SmJvmService, SmJvmServiceStarter
 from ..smfile import force_chdir, force_pushdir, remove_if_exists, remove_folder_if_exists, makedirs_if_not_exists
-from ..smnexus import SmNexus
+from ..smartifactrepofactory import SmArtifactRepoFactory
 from ..actions.colours import BColors
 
 from servicemanager import subprocess
@@ -88,12 +89,13 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
         force_chdir(microservice_target_path)
 
         if not self.context.offline:
-            nexus = SmNexus(self.context, self.service_name)
+            binaryConfig = self.service_data["binary"]
+            artifactRepo = SmArtifactRepoFactory.get_repository(self.context, self.service_name, binaryConfig)
             if not self.version:
-                self.version = nexus.find_latest_version(self.run_from, self.service_data["binary"]["artifact"])
-            nexus.download_jar_if_necessary(self.run_from, self.version)
+                self.version = artifactRepo.find_latest_version(self.run_from, binaryConfig["artifact"])
+            artifactRepo.download_jar_if_necessary(self.run_from, self.version)
 
-        unzip_dir = self._unzip_play_application()
+        unzip_dir = self._unpack_play_application(SmArtifactRepoFactory.get_play_app_extension(binaryConfig))
         parent, _ = os.path.split(unzip_dir)
         force_pushdir(parent)
 
@@ -117,23 +119,37 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
                 print b.fail + "ERROR: could not start '" + self.service_name + "' " + b.endc
             return popen_output.pid
 
-    def _unzip_play_application(self):
+    def _unpack_play_application(self, extension):
         service_data = self.service_data
         microservice_zip_path = self.context.application.workspace + service_data["location"] + "/target/"
         force_pushdir(microservice_zip_path)
-        zip_filename = service_data["binary"]["artifact"] + ".zip"
+        zip_filename = service_data["binary"]["artifact"] + extension
 
         unzipped_dir = SmPlayService.unzipped_dir_path(self.context, service_data["location"])
         remove_folder_if_exists(unzipped_dir)
 
         os.makedirs(unzipped_dir)
-        zipfile.ZipFile(zip_filename, 'r').extractall(unzipped_dir)
 
-        folder = os.listdir(unzipped_dir)[0]
+        if extension == ".zip":
+            self._unzip_play_application(zip_filename, unzipped_dir)
+        elif extension == ".tgz":
+            self._untar_play_application(zip_filename, unzipped_dir)
+        else:
+            print "ERROR: unsupported atrifact extension: " + extension         
+
+        
+        folder = [ name for name in os.listdir(unzipped_dir) if os.path.isdir(os.path.join(unzipped_dir, name)) ][0]
         target_dir = unzipped_dir + "/" + service_data["binary"]["destinationSubdir"]
         shutil.move(unzipped_dir + "/" + folder, target_dir)
 
         return target_dir
+
+    def _unzip_play_application(self, zip_filename, unzipped_dir):
+        zipfile.ZipFile(zip_filename, 'r').extractall(unzipped_dir)
+
+    def _untar_play_application(self, tgz_filename, unzipped_dir):
+        tfile = tarfile.open(tgz_filename, 'r:gz')
+        tfile.extractall(unzipped_dir) 
 
     def sbt_extra_params(self):
         sbt_extra_params = self._build_extra_params()

--- a/servicemanager/smartifactrepofactory.py
+++ b/servicemanager/smartifactrepofactory.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from smnexus import SmNexus
+from smbintray import SmBintray
+
+
+class SmArtifactRepoFactory():
+
+    @staticmethod
+    def get_repository(context, service_name, service_binary_config):
+    	if SmArtifactRepoFactory._is_nexus(service_binary_config):
+            return SmNexus(context, service_name)
+        else:
+            return SmBintray(context, service_name)
+
+    @staticmethod
+    def get_play_app_extension(service_binary_config):
+        if SmArtifactRepoFactory._is_nexus(service_binary_config):
+            return ".zip"
+        else:
+            return ".tgz"
+
+    @staticmethod
+    def _is_nexus(service_binary_config):
+        if "nexus" in service_binary_config:
+            return True
+        else:
+        	return False    
+

--- a/servicemanager/smbintray.py
+++ b/servicemanager/smbintray.py
@@ -3,13 +3,12 @@ import sys
 import urllib
 import urllib2
 import base64
-import json
-
 import requests
 
 from servicemanager.smfile import remove_if_exists
 from actions.colours import BColors
 from smnexus import SmNexus
+from xml.dom.minidom import parse
 
 
 b = BColors()
@@ -21,46 +20,26 @@ class SmBintray():
         self.context = context
         self.service_name = service_name
         self.service_type = context.service_type(service_name)
+   
+    def _find_latest_in_dom(self, dom):
+        try:
+            data = dom.getElementsByTagName("versioning")[0]
+        except:
+            self.context.log("Unable to get latest version from bintray")
+            return None
 
+        latestVersion =  data.getElementsByTagName("latest")[0].firstChild.nodeValue
+        return latestVersion
 
-    def _resolve_credentials(self):
-        return {'user': os.environ.get("BINTRAY_USER", ""), 'password': os.environ.get("BINTRAY_PASS", "")}
-        
-    def _header_credentials(self):
-        credentials = self._resolve_credentials()
-        return credentials["user"] + ":" + credentials["password"]
-
-    def _get_version_info_from_bintray(self, artifact, repositoryId):
-        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["apiHost"] + "/packages/" + repositoryId + "/" + artifact + "/versions/_latest"
+    def _get_version_info_from_bintray(self, artifact, repositoryId, groupId):
+        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["host"] + "/" + repositoryId + "/" + groupId + artifact + "/maven-metadata.xml"
         request = urllib2.Request(url)
-        base64string = base64.encodestring(self._header_credentials()).replace('\n', '')
-        request.add_header("Authorization", "Basic %s" % base64string)
-        response = urllib2.urlopen(request).read()
-        json_data = json.loads(response)
-        return json_data["name"]
+        response = urllib2.urlopen(request)
+        dom = parse(response)
+        response.close()
+        return self._find_latest_in_dom(dom)
 
-    def _get_version_files_from_bintray(self, artifact, repositoryId, version):
-        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["apiHost"] + "/packages/" + repositoryId + "/" + artifact + "/versions/" + version + "/files"
-        request = urllib2.Request(url)        
-        base64string = base64.encodestring(self._header_credentials()).replace('\n', '')
-        request.add_header("Authorization", "Basic %s" % base64string)
-        response = urllib2.urlopen(request).read()
-        json_data = json.loads(response)
-        return json_data    
-
-    def _find_tgz_file_path(self, version_files_json):
-        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz")]
-        return tgzFiles[0]["path"]
-
-    def _find_tgz_file_name(self, version_files_json):
-        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz")]
-        return tgzFiles[0]["name"]   
-
-    def _find_md5_file_path(self, version_files_json):
-        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz.md5")]
-        return tgzFiles[0]["path"]   
-
-    def find_latest_version(self, run_from, artifact):    
+    def find_latest_version(self, run_from, artifact, groupId):    
         version_env_var = None
         if "versionEnv" in self.context.service_data(self.service_name):
             version_env_var = self.context.service_data(self.service_name)["versionEnv"]
@@ -69,11 +48,11 @@ class SmBintray():
             version = os.environ[version_env_var]
         except Exception:
             repo_mappings = self.context.config_value("bintray")["repoMappings"]
-            version = self._get_version_info_from_bintray(artifact, repo_mappings[run_from])
+            version = self._get_version_info_from_bintray(artifact, repo_mappings[run_from], groupId)
         return version
 
     def _download_from_bintray(self, bintray_path, local_filename, repositoryId, show_progress):
-        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["downloadHost"] + "/" + repositoryId + "/" + bintray_path
+        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["host"] + "/" + repositoryId + "/" + bintray_path
         if show_progress:
             urllib.urlretrieve(url, local_filename, SmNexus._report_hook)
             print("\n")
@@ -82,23 +61,25 @@ class SmBintray():
 
     def download_jar_if_necessary(self, run_from, version):
         artifact = self.context.service_data(self.service_name)["binary"]["artifact"]
+        groupId = self.context.service_data(self.service_name)["binary"]["groupId"]
         repo_mappings = self.context.config_value("bintray")["repoMappings"]
+        repositoryId = repo_mappings[run_from]
 
         if not version:
-            version = self.find_latest_version(run_from, artifact)
-
-        files_json = self._get_version_files_from_bintray(artifact, repo_mappings[run_from], version)
-        localFilename = artifact + ".tgz"
-        bintrayFilePath = self._find_tgz_file_path(files_json)
-        bintrayFilename = self._find_tgz_file_name(files_json)
-        bintrayMD5FilePath = self._find_md5_file_path(files_json)
-        microservice_target_path = self.context.get_microservice_target_path(self.service_name)
-        downloaded_artifact_path = microservice_target_path + localFilename
-        downloaded_md5_path = microservice_target_path + localFilename + ".md5"
+            version = self.find_latest_version(run_from, artifact, groupId)
 
         if version:   
+
+            localFilename = artifact + ".tgz"
+            bintrayFilename = artifact + "-" + str(version) + ".tgz"
+            bintrayFilePath = groupId + artifact + "/" + str(version) + "/" + bintrayFilename
+            bintrayMD5FilePath = bintrayFilePath + ".md5"
+            microservice_target_path = self.context.get_microservice_target_path(self.service_name)
+            downloaded_artifact_path = microservice_target_path + localFilename
+            downloaded_md5_path = microservice_target_path + localFilename + ".md5"
+
              #first download the md5 file in order to determine if new artifact download is required
-            self._download_from_bintray(bintrayMD5FilePath, downloaded_md5_path, repo_mappings[run_from], False)
+            self._download_from_bintray(bintrayMD5FilePath, downloaded_md5_path, repositoryId, False)
 
             bintray_md5 = open(downloaded_md5_path, 'r').read()
             local_md5 = SmNexus._md5_if_exists(downloaded_artifact_path)
@@ -106,7 +87,7 @@ class SmBintray():
             if local_md5 != bintray_md5:
                 remove_if_exists(downloaded_artifact_path)
                 self.context.log("Downloading Bintray binary for '" + self.service_name + "': " + bintrayFilename)
-                self._download_from_bintray(bintrayFilePath, downloaded_artifact_path, repo_mappings[run_from], self.context.show_progress)
+                self._download_from_bintray(bintrayFilePath, downloaded_artifact_path, repositoryId, self.context.show_progress)
             os.remove(downloaded_md5_path)
         else:
             print b.warning + "WARNING: Due to lack of version data from Bintray you may not have an up to date version..." + b.endc    

--- a/servicemanager/smbintray.py
+++ b/servicemanager/smbintray.py
@@ -1,0 +1,112 @@
+import os
+import sys
+import urllib
+import urllib2
+import base64
+import json
+
+import requests
+
+from servicemanager.smfile import remove_if_exists
+from actions.colours import BColors
+from smnexus import SmNexus
+
+
+b = BColors()
+
+
+class SmBintray():
+
+    def __init__(self, context, service_name):
+        self.context = context
+        self.service_name = service_name
+        self.service_type = context.service_type(service_name)
+
+
+    def _resolve_credentials(self):
+        return {'user': os.environ.get("BINTRAY_USER", ""), 'password': os.environ.get("BINTRAY_PASS", "")}
+        
+    def _header_credentials(self):
+        credentials = self._resolve_credentials()
+        return credentials["user"] + ":" + credentials["password"]
+
+    def _get_version_info_from_bintray(self, artifact, repositoryId):
+        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["apiHost"] + "/packages/" + repositoryId + "/" + artifact + "/versions/_latest"
+        request = urllib2.Request(url)
+        base64string = base64.encodestring(self._header_credentials()).replace('\n', '')
+        request.add_header("Authorization", "Basic %s" % base64string)
+        response = urllib2.urlopen(request).read()
+        json_data = json.loads(response)
+        return json_data["name"]
+
+    def _get_version_files_from_bintray(self, artifact, repositoryId, version):
+        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["apiHost"] + "/packages/" + repositoryId + "/" + artifact + "/versions/" + version + "/files"
+        request = urllib2.Request(url)        
+        base64string = base64.encodestring(self._header_credentials()).replace('\n', '')
+        request.add_header("Authorization", "Basic %s" % base64string)
+        response = urllib2.urlopen(request).read()
+        json_data = json.loads(response)
+        return json_data    
+
+    def _find_tgz_file_path(self, version_files_json):
+        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz")]
+        return tgzFiles[0]["path"]
+
+    def _find_tgz_file_name(self, version_files_json):
+        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz")]
+        return tgzFiles[0]["name"]   
+
+    def _find_md5_file_path(self, version_files_json):
+        tgzFiles = [element for element in version_files_json if element['name'].endswith(".tgz.md5")]
+        return tgzFiles[0]["path"]   
+
+    def find_latest_version(self, run_from, artifact):    
+        version_env_var = None
+        if "versionEnv" in self.context.service_data(self.service_name):
+            version_env_var = self.context.service_data(self.service_name)["versionEnv"]
+
+        try:
+            version = os.environ[version_env_var]
+        except Exception:
+            repo_mappings = self.context.config_value("bintray")["repoMappings"]
+            version = self._get_version_info_from_bintray(artifact, repo_mappings[run_from])
+        return version
+
+    def _download_from_bintray(self, bintray_path, local_filename, repositoryId, show_progress):
+        url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["downloadHost"] + "/" + repositoryId + "/" + bintray_path
+        if show_progress:
+            urllib.urlretrieve(url, local_filename, SmNexus._report_hook)
+            print("\n")
+        else:
+            urllib.urlretrieve(url, local_filename)
+
+    def download_jar_if_necessary(self, run_from, version):
+        artifact = self.context.service_data(self.service_name)["binary"]["artifact"]
+        repo_mappings = self.context.config_value("bintray")["repoMappings"]
+
+        if not version:
+            version = self.find_latest_version(run_from, artifact)
+
+        files_json = self._get_version_files_from_bintray(artifact, repo_mappings[run_from], version)
+        localFilename = artifact + ".tgz"
+        bintrayFilePath = self._find_tgz_file_path(files_json)
+        bintrayFilename = self._find_tgz_file_name(files_json)
+        bintrayMD5FilePath = self._find_md5_file_path(files_json)
+        microservice_target_path = self.context.get_microservice_target_path(self.service_name)
+        downloaded_artifact_path = microservice_target_path + localFilename
+        downloaded_md5_path = microservice_target_path + localFilename + ".md5"
+
+        if version:   
+             #first download the md5 file in order to determine if new artifact download is required
+            self._download_from_bintray(bintrayMD5FilePath, downloaded_md5_path, repo_mappings[run_from], False)
+
+            bintray_md5 = open(downloaded_md5_path, 'r').read()
+            local_md5 = SmNexus._md5_if_exists(downloaded_artifact_path)
+
+            if local_md5 != bintray_md5:
+                remove_if_exists(downloaded_artifact_path)
+                self.context.log("Downloading Bintray binary for '" + self.service_name + "': " + bintrayFilename)
+                self._download_from_bintray(bintrayFilePath, downloaded_artifact_path, repo_mappings[run_from], self.context.show_progress)
+            os.remove(downloaded_md5_path)
+        else:
+            print b.warning + "WARNING: Due to lack of version data from Bintray you may not have an up to date version..." + b.endc    

--- a/servicemanager/smnexus.py
+++ b/servicemanager/smnexus.py
@@ -117,7 +117,7 @@ class SmNexus():
         response.close()
         return dom
 
-    def find_latest_version(self, run_from, artifact):
+    def find_latest_version(self, run_from, artifact, groupId):
         if run_from == "RELEASE":
             repository = "Release"
         else:
@@ -150,6 +150,7 @@ class SmNexus():
         binary = self.context.service_data(self.service_name)["binary"]
         nexus_host = self.context.application.nexus_repo_host
         artifact = binary["artifact"]
+        group_id = binary["groupId"]
         filename = self.context.get_jar_filename(self.service_name, run_from)
         microservice_target_path = self.context.get_microservice_target_path(self.service_name)
         repo_mappings = self.context.config_value("nexus")["repoMappings"]
@@ -159,13 +160,12 @@ class SmNexus():
             url_type_repository = repo_mappings["SNAPSHOT"]
 
         if not version:
-            version = self.find_latest_version(run_from, artifact)
+            version = self.find_latest_version(run_from, artifact, group_id)
 
         if version:
             nexus_extension = self._create_nexus_extension()
             nexus_filename = artifact + "-" + version + nexus_extension
             md5_filename = nexus_filename + ".md5"
-            group_id = binary["groupId"]
             nexus_url = nexus_host + binary["nexus"] + url_type_repository + "/" + group_id + artifact + "/" + version + "/"
             #first download the md5 file in order to determine if new artifact download is required
             self._download_from_nexus(nexus_url + md5_filename, microservice_target_path + md5_filename, False)

--- a/servicemanager/smnexus.py
+++ b/servicemanager/smnexus.py
@@ -172,12 +172,12 @@ class SmNexus():
             if self.service_type == "assets":
                 if self._md5_if_exists(microservice_target_path + nexus_filename) != open(microservice_target_path + md5_filename, 'r').read():
                     remove_if_exists(microservice_target_path + filename)
-                    self.context.log("Downloading binary for '" + self.service_name + "': " + nexus_filename)
+                    self.context.log("Downloading Nexus binary for '" + self.service_name + "': " + nexus_filename)
                     self._download_from_nexus(nexus_url + nexus_filename, nexus_filename, self.context.show_progress)
             else:
                 if self._md5_if_exists(microservice_target_path + filename) != open(microservice_target_path + md5_filename, 'r').read():
                     remove_if_exists(microservice_target_path + filename)
-                    self.context.log("Downloading binary for '" + self.service_name + "': " + nexus_filename)
+                    self.context.log("Downloading Nexus binary for '" + self.service_name + "': " + nexus_filename)
                     self._download_from_nexus(nexus_url + nexus_filename, filename, self.context.show_progress)
             os.remove(microservice_target_path + md5_filename)
         else:

--- a/test/conf/config.json
+++ b/test/conf/config.json
@@ -7,5 +7,14 @@
                 "SNAPSHOT" : "foo-snapshots"
              }
 	},
+	"bintray" : {
+		"protocol": "http",
+		"apiHost": "localhost:8061",
+		"downloadHost" : "localhost:8061",
+        "repoMappings" : {
+            "RELEASE" : "hmrc/releases",
+            "SNAPSHOT" : "hmrc/release-candidates"
+        }
+	},
 	"playExtractionDir" : "/var/tmp"
 }

--- a/test/conf/config.json
+++ b/test/conf/config.json
@@ -9,8 +9,7 @@
 	},
 	"bintray" : {
 		"protocol": "http",
-		"apiHost": "localhost:8061",
-		"downloadHost" : "localhost:8061",
+		"host" : "localhost:8061",
         "repoMappings" : {
             "RELEASE" : "hmrc/releases",
             "SNAPSHOT" : "hmrc/release-candidates"

--- a/test/conf/services.json
+++ b/test/conf/services.json
@@ -13,6 +13,20 @@
         },
         "pattern": ".*fakenexus.*"
     },
+    "FAKE_BINTRAY": {
+        "name": "Simple bintray mock server",
+        "type": "external",
+        "location": "../",
+        "cmd": [
+            "python",
+            "fakebintray.py"
+        ],
+        "healthcheck": {
+            "url": "http://localhost:8061/ping",
+            "response": "pong"
+        },
+        "pattern": ".*fakebintray.*"
+    },
     "TEST_ONE": {
         "name": "Test service one",
         "type": "external",
@@ -113,6 +127,40 @@
              "artifact": "playtest",
              "groupId":"foo/bar/foo/",
              "nexus": "/content/repositories/",
+             "destinationSubdir" : "basicplayapp",
+             "cmd": [
+                     "./basicplayapp/bin/basicplayapp",
+                     "-DProd.microservice.whitelist.useWhitelist=false",
+                     "-DProd.mongodb.uri=mongodb://localhost:27017/auth",
+                     "-J-Xmx256m",
+                     "-J-Xms256m",
+                     "-J-XX:MaxPermSize=128m"
+            ]
+        }
+    },
+    "PLAY_BINTRAY_END_TO_END_TEST": {
+        "name": "A simple play application for testing on Bintray",
+        "type": "play",
+        "location": "/testapps/basicplayapp",
+        "hasServiceMappings": true,
+        "defaultPort" : 8500,
+        "hasMongo" : true,
+        "healthcheck": {
+            "url": "http://localhost:${port}",
+            "response": ""
+        },
+        "sources": {
+            "cmd": [
+                "play",
+                "start"
+            ],
+            "extra_params": [
+                 "-DFoo=false"
+            ],
+            "repo": "git@github.com:hmrc/service-manager.git"
+        },
+        "binary": {
+             "artifact": "playtest",
              "destinationSubdir" : "basicplayapp",
              "cmd": [
                      "./basicplayapp/bin/basicplayapp",

--- a/test/conf/services.json
+++ b/test/conf/services.json
@@ -160,7 +160,8 @@
             "repo": "git@github.com:hmrc/service-manager.git"
         },
         "binary": {
-             "artifact": "playtest",
+             "artifact": "playtest_2.11",
+             "groupId":"uk/gov/hmrc/",
              "destinationSubdir" : "basicplayapp",
              "cmd": [
                      "./basicplayapp/bin/basicplayapp",

--- a/test/fakebintray.py
+++ b/test/fakebintray.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+from bottle import route, run, request
+from bottle import static_file
+
+LATEST_VERSION_RESPONSE="""
+{"name":"1.26.0-3-gd7ed03c","desc":null,"package":"playtest","repo":"release-candidates","owner":"hmrc","labels":[],"attribute_names":[],"created":"2015-08-04T14:35:27.173Z","updated":"2015-08-04T14:38:26.150Z","released":"2015-08-04T14:35:38.862Z","ordinal":3.0,"github_release_notes_file":null,"github_use_tag_release_notes":false,"vcs_tag":null}
+"""
+
+VERSION_FILES_RESPONSE="""
+[
+{"name":"playtest_2.11-1.26.0-3-gd7ed03c-javadoc.jar",
+"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c-javadoc.jar",
+"repo":"release-candidates",
+"package":"playtest","version":"1.26.0-3-gd7ed03c",
+"owner":"hmrc",
+"created":"2015-08-04T14:35:30.567Z",
+"size":489312,
+"sha1":"1c058c5e516f76ce5beb90931d3db00114560991"
+},{
+"name":"playtest_2.11-1.26.0-3-gd7ed03c.tgz",
+"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz",
+"repo":"release-candidates",
+"package":"playtest",
+"version":"1.26.0-3-gd7ed03c",
+"owner":"hmrc",
+"created":"2015-08-04T14:36:47.013Z",
+"size":32643270,
+"sha1":"5c6d23596ba70e47fc5623275853676fc4a521ef"
+},{
+"name":"playtest_2.11-1.26.0-3-gd7ed03c.tgz.md5",
+"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz.md5",
+"repo":"release-candidates",
+"package":"playtest",
+"version":"1.26.0-3-gd7ed03c",
+"owner":"hmrc",
+"created":"2015-08-04T14:36:47.013Z",
+"size":32643270,
+"sha1":"5c6d23596ba70e47fc5623275853676fc4a521ef"
+}]
+"""
+
+@route('/ping')
+def ping():
+    return "pong"
+
+@route('/packages/hmrc/release-candidates/playtest/versions/_latest')
+def latest_version():
+    return LATEST_VERSION_RESPONSE
+
+@route("/packages/hmrc/release-candidates/playtest/versions/1.26.0-3-gd7ed03c/files")
+def version_files():
+    return VERSION_FILES_RESPONSE
+
+@route("/packages/hmrc/release-candidates/playtest/versions/1.26.0-3-gd7ed03c/files")
+def version_files():
+    return VERSION_FILES_RESPONSE
+
+@route('/hmrc/release-candidates/uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz')
+def server_static_tgz():
+    return static_file("bintray/playtest.tgz", root="./static/")
+
+@route('/hmrc/release-candidates/uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz.md5')
+def server_static_md5():
+    return static_file("bintray/playtest.tgz.md5", root="./static/")
+
+run(host='localhost', port=8061)

--- a/test/fakebintray.py
+++ b/test/fakebintray.py
@@ -3,58 +3,31 @@
 from bottle import route, run, request
 from bottle import static_file
 
-LATEST_VERSION_RESPONSE="""
-{"name":"1.26.0-3-gd7ed03c","desc":null,"package":"playtest","repo":"release-candidates","owner":"hmrc","labels":[],"attribute_names":[],"created":"2015-08-04T14:35:27.173Z","updated":"2015-08-04T14:38:26.150Z","released":"2015-08-04T14:35:38.862Z","ordinal":3.0,"github_release_notes_file":null,"github_use_tag_release_notes":false,"vcs_tag":null}
-"""
+MAVEN_METADATA="""<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>uk.gov.hmrc</groupId>
+  <artifactId>help-frontend_2.11</artifactId>
+  <version>1.26.0-3-gd7ed03c</version>
+  <versioning>
+    <latest>1.26.0-3-gd7ed03c</latest>
+    <release>1.26.0-3-gd7ed03c</release>
+    <versions>
+      <version>1.26.0-1-gd0dba7c</version>
+      <version>1.26.0-2-gd213a4f</version>
+      <version>1.26.0-3-gd7ed03c</version>
+    </versions>
+    <lastUpdated>20150804143826</lastUpdated>
+  </versioning>
+</metadata>"""
 
-VERSION_FILES_RESPONSE="""
-[
-{"name":"playtest_2.11-1.26.0-3-gd7ed03c-javadoc.jar",
-"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c-javadoc.jar",
-"repo":"release-candidates",
-"package":"playtest","version":"1.26.0-3-gd7ed03c",
-"owner":"hmrc",
-"created":"2015-08-04T14:35:30.567Z",
-"size":489312,
-"sha1":"1c058c5e516f76ce5beb90931d3db00114560991"
-},{
-"name":"playtest_2.11-1.26.0-3-gd7ed03c.tgz",
-"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz",
-"repo":"release-candidates",
-"package":"playtest",
-"version":"1.26.0-3-gd7ed03c",
-"owner":"hmrc",
-"created":"2015-08-04T14:36:47.013Z",
-"size":32643270,
-"sha1":"5c6d23596ba70e47fc5623275853676fc4a521ef"
-},{
-"name":"playtest_2.11-1.26.0-3-gd7ed03c.tgz.md5",
-"path":"uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz.md5",
-"repo":"release-candidates",
-"package":"playtest",
-"version":"1.26.0-3-gd7ed03c",
-"owner":"hmrc",
-"created":"2015-08-04T14:36:47.013Z",
-"size":32643270,
-"sha1":"5c6d23596ba70e47fc5623275853676fc4a521ef"
-}]
-"""
 
 @route('/ping')
 def ping():
     return "pong"
 
-@route('/packages/hmrc/release-candidates/playtest/versions/_latest')
-def latest_version():
-    return LATEST_VERSION_RESPONSE
-
-@route("/packages/hmrc/release-candidates/playtest/versions/1.26.0-3-gd7ed03c/files")
-def version_files():
-    return VERSION_FILES_RESPONSE
-
-@route("/packages/hmrc/release-candidates/playtest/versions/1.26.0-3-gd7ed03c/files")
-def version_files():
-    return VERSION_FILES_RESPONSE
+@route('/hmrc/release-candidates/uk/gov/hmrc/playtest_2.11/maven-metadata.xml')
+def maven_metadata():
+    return MAVEN_METADATA
 
 @route('/hmrc/release-candidates/uk/gov/hmrc/playtest_2.11/1.26.0-3-gd7ed03c/playtest_2.11-1.26.0-3-gd7ed03c.tgz')
 def server_static_tgz():

--- a/test/static/bintray/playtest.tgz.md5
+++ b/test/static/bintray/playtest.tgz.md5
@@ -1,0 +1,1 @@
+8adcfef23a7cf98a412b1970d6daf4d9

--- a/test/tests.py
+++ b/test/tests.py
@@ -82,6 +82,31 @@ class TestNexus(unittest.TestCase):
         self.assertEqual(context.get_service("FAKE_NEXUS").status(), [])
 
 
+class TestBintray(unittest.TestCase):
+    def setUp(self):
+        set_up_and_clean_workspace()
+
+    def test_bintray(self):
+        config_dir_override = os.path.join(os.path.dirname(__file__), "conf")
+
+        # start fake bintray
+        context = SmContext(SmApplication(config_dir_override), None, False, False)
+        response1 = actions.start_one(context, "FAKE_BINTRAY", True, False, None, port=None)
+        self.assertIsNotNone(context.get_service("FAKE_BINTRAY").status())
+        time.sleep(5)
+
+        context = SmContext(SmApplication(config_dir_override), None, False, False)
+        servicetostart = "PLAY_BINTRAY_END_TO_END_TEST"
+        actions.start_one(context, servicetostart, True, False, None, port=None)
+        self.assertIsNotNone(context.get_service(servicetostart).status())
+        context.kill(servicetostart)
+
+        context.kill("FAKE_BINTRAY")
+
+        self.assertEqual(context.get_service(servicetostart).status(), [])
+        self.assertEqual(context.get_service("FAKE_BINTRAY").status(), [])
+
+
 class TestActions(unittest.TestCase):
     def setUp(self):
         set_up_and_clean_workspace()
@@ -561,7 +586,7 @@ class TestConfiguration(unittest.TestCase):
     def test_config(self):
         config_dir_override = os.path.join(os.path.dirname(__file__), "conf")
         application = SmApplication(config_dir_override, None)
-        self.assertEqual(len(application.services), 9)
+        self.assertEqual(len(application.services), 11)
         self.assertEqual(application.services["TEST_TEMPLATE"]["type"], "external")
         self.assertEqual(application.services["TEST_TEMPLATE"]["pattern"], "some.namespace=TEST_TEMPLATE")
         self.assertEqual(application.services["TEST_TEMPLATE"]["includeInStartAndStopAll"], False)
@@ -592,7 +617,7 @@ class TestServiceResolver(unittest.TestCase):
         self.assertTrue("DROPWIZARD_NEXUS_END_TO_END_TEST" in all_services)
         self.assertTrue("PLAY_NEXUS_END_TO_END_TEST" in all_services)
         self.assertTrue("PYTHON_SIMPLE_SERVER_ASSETS_FRONTEND" in all_services)
-        self.assertEqual(9, len(all_services))
+        self.assertEqual(11, len(all_services))
 
         test_profile = service_resolver.resolve_services("TEST")
         self.assertTrue("TEST_ONE" in test_profile)


### PR DESCRIPTION
To invoke this, services should drop this from their configs:

binary.groupId
binary.nexus

binary.artifact should lose the _2.10 or _2.11 suffix (and use the repo name as it is in bintray)

Users must set these env variables:

BINTRAY_USER = [bintray_username]
BINTRAY_PASS = [bintray_api_key]
