### PR TITLE
Upgrade dependencies to avoid Ubuntu SSLv3 being missing

### DIFF
--- a/servicemanager/smprocess.py
+++ b/servicemanager/smprocess.py
@@ -46,6 +46,9 @@ def _is_system_or_smserver_or_test_process(pid):
     if _is_pycharm_related_process(pid):
         return True
 
+    if _is_upstart_process(pid):
+        return True
+
     return False
 
 
@@ -85,6 +88,10 @@ def _is_pycharm_process(pid):
 
 def _is_pycharm_related_process(pid):
     command = "ps -eo pid,args | grep %d | grep 'pycharm' | awk '{print $1}'" % pid
+    return _is_pid_in_list(pid, command)
+
+def _is_upstart_process(pid):
+    command = "ps -eo pid,args | grep %d | grep 'upstart' | awk '{print $1}'" % pid
     return _is_pid_in_list(pid, command)
 
 
@@ -206,3 +213,4 @@ class SmProcess:
             return int(arg)
 
         return default_if_none
+


### PR DESCRIPTION
With the latest version of Ubuntu, sm crashes out with the error:
```
  File "/tmp/easy_install-A0ku50/requests-2.2.1/requests/packages/urllib3/contrib/pyopenssl.py", line 62, in <module>
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
```
Debian removed SSLv3 from OpenSSL due to a security flaw. The latest version of urllib3 checks to see if SSLv3 exists in OpenSSL before importing it.