### PR TITLE
Order of service start log statements

### DIFF
--- a/servicemanager/smcontext.py
+++ b/servicemanager/smcontext.py
@@ -349,9 +349,9 @@ class SmContext():
         return starter
 
     def start_service(self, service_name, run_from, proxy, classifier=None, service_mapping_ports=None, port=None, admin_port=None, version=None, appendArgs=None):
-        service_starter = self.get_service_starter(service_name, run_from, proxy, classifier, service_mapping_ports, port, admin_port, version, appendArgs)
         feature_string = pretty_print_list(" with feature$s $list enabled", self.features)
         self.log("Starting '%s' from %s%s..." % (service_name, run_from, feature_string))
+        service_starter = self.get_service_starter(service_name, run_from, proxy, classifier, service_mapping_ports, port, admin_port, version, appendArgs)
         service_process_id = service_starter.start()
 
         if service_process_id:


### PR DESCRIPTION
In the case of services which are overridden to always use release
versions, the console out logging can be slightly misleading as to which
version actually started up.

ie.
Service 'MYSERVICE' has been overridden to always use 'RELEASE' version
Starting 'MYSERVICE' from SNAPSHOT...

This logging is trying to indicate that a snapshot was request but a
release version was actually started. Reversing the order which these
lines appear in the console log would make it clearer that that actually
happened.

ie.
Starting 'MYSERVICE' from SNAPSHOT...
Service 'MYSERVICE' has been overridden to always use 'RELEASE' version