### PR TITLE
Make requirements.txt more dependency friendly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests==2.8.1
-pymongo==3.0.1
-bottle==0.12.4
-pytest==2.5.2
-argcomplete==0.8.1
-pyhamcrest==1.8.3
-mock==1.0.1
+requests>=2.8.1
+pymongo>=3.0.1
+bottle>=0.12.4
+pytest>=2.5.2
+argcomplete>=0.8.1
+pyhamcrest>=1.8.3
+mock>=1.0.1


### PR DESCRIPTION
I'd like to propose defining the requirements using a lower bound >= rather than a strict == equality. This would help reducing dependency conflict. Using lower bound definitions would be an improvement over '==', for a library (_reusable component_). See [the-package-dependency-blues](http://blog.miguelgrinberg.com/post/the-package-dependency-blues) for more requirements.txt related good practices.
