### PR TITLE
[SDT-133] remove reference to assets version Prod namespace

### DIFF
--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -87,7 +87,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
     def start_from_binary(self):
         microservice_target_path = self.context.get_microservice_target_path(self.service_name)
         force_chdir(microservice_target_path)
-        
+
         binaryConfig = self.service_data["binary"]
 
         if not self.context.offline:
@@ -136,9 +136,9 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
         elif extension == ".tgz":
             self._untar_play_application(microservice_filename, unpacked_dir)
         else:
-            print "ERROR: unsupported atrifact extension: " + extension         
+            print "ERROR: unsupported atrifact extension: " + extension
 
-        
+
         folder = [ name for name in os.listdir(unpacked_dir) if os.path.isdir(os.path.join(unpacked_dir, name)) ][0]
         target_dir = unpacked_dir + "/" + service_data["binary"]["destinationSubdir"]
         shutil.move(unpacked_dir + "/" + folder, target_dir)
@@ -150,7 +150,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
 
     def _untar_play_application(self, tgz_filename, unzipped_dir):
         tfile = tarfile.open(tgz_filename, 'r:gz')
-        tfile.extractall(unzipped_dir) 
+        tfile.extractall(unzipped_dir)
 
     def sbt_extra_params(self):
         sbt_extra_params = self._build_extra_params()
@@ -185,14 +185,9 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
             with file(conf_file) as conf:
                 conf = conf.read()
                 conf_string = "".join(conf.split())
-                pattern = re.compile(ur'Prod.*assets.*version="([0-9.]*)"')
+                pattern = re.compile(ur'assets.*version="([0-9.]*)"')
                 new_assets_versions = re.findall(pattern, conf_string)
-                
-                # Frontends in the open do not have a Prod section in their application.conf
-                if not new_assets_versions:
-                  pattern = re.compile(ur'assets.*version="([0-9.]*)"')
-                  new_assets_versions = re.findall(pattern, conf_string)
-                  
+
                 assets_versions = assets_versions + new_assets_versions
         return assets_versions
 

--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -185,11 +185,11 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
             with file(conf_file) as conf:
                 conf = conf.read()
                 conf_string = "".join(conf.split())
-                pattern = re.compile(ur'assets.*version="([0-9.]*)"')
+                pattern = re.compile(ur'assets.*?version="([0-9.]*)"')
                 new_assets_versions = re.findall(pattern, conf_string)
 
                 assets_versions = assets_versions + new_assets_versions
-        return assets_versions
+        return list(set(assets_versions))
 
 class SmPlayService(SmJvmService):
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 setup(name='servicemanager',
-      version='0.6.0',
+      version='0.7.0',
       description='A python tool to manage developing and testing with lots of microservices',
       url='https://github.com/hmrc/service-manager',
       author='hmrc-web-operations',

--- a/test/testapps/basicplayapp/conf/application.conf
+++ b/test/testapps/basicplayapp/conf/application.conf
@@ -57,6 +57,18 @@ logger.play=INFO
 # Logger provided to your application:
 logger.application=DEBUG
 
+assets.version = "2.150.0"
+
+assets {
+  version = "2.150.0"
+}
+
+Dev {
+  assets {
+    version = ${?Prod.assets.version}
+  }
+}
+
 Prod {
   assets {
     version = "2.149.0"

--- a/test/unit/test_smplayservice.py
+++ b/test/unit/test_smplayservice.py
@@ -11,7 +11,7 @@ class TestSmPlayService(unittest.TestCase):
     self.sm_play_service = SmPlayServiceStarter(sm_context, "PLAY_NEXUS_END_TO_END_TEST", "", "", 9000, "", "", "", "")
 
   def test_closed_assets_config(self):
-    assert_that(self.sm_play_service._get_assets_version("test/testapps/basicplayapp"), has_item("2.149.0"))
+    assert_that(self.sm_play_service._get_assets_version("test/testapps/basicplayapp"), equal_to(["2.149.0", "2.150.0"]))
 
   def test_open_assets_config(self):
     assert_that(self.sm_play_service._get_assets_version("test/testapps/openplayapp"), has_item("2.150.0"))


### PR DESCRIPTION
There is work around standardising Service frontends `assets.version` `Prod` namespace. This work removes the `Prod.*assets.*version="([0-9.]*)` regex.

Related PR's:
https://github.com/hmrc/play-ui/pull/61
https://github.com/hmrc/init-service/pull/13

### Of Note
The current regex will continue to match `assets.version` within the `Prod` namespace. I don't feel this is the responsibility of service manager to enforce the `assets.version` config structure but I have raised an issue around this. #60 

Also the tests around the [Prod](https://github.com/hmrc/service-manager/blob/SDT-133-remove-assets-version-prod-namespace/test/unit/test_smplayservice.py) namesapce continue to pass due to the above issue.