### PR TITLE
Removed usage of force_pushdir call as it relies on os.getcwd which w…

### DIFF
--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -13,7 +13,7 @@ import types
 from servicemanager.subprocess import Popen
 from servicemanager.service.smservice import SmMicroServiceStarter
 from servicemanager.service.smjvmservice import SmJvmService, SmJvmServiceStarter
-from servicemanager.smfile import force_chdir, force_pushdir, remove_if_exists, remove_folder_if_exists, makedirs_if_not_exists
+from servicemanager.smfile import force_chdir, remove_if_exists, remove_folder_if_exists, makedirs_if_not_exists
 from servicemanager.smartifactrepofactory import SmArtifactRepoFactory
 from servicemanager.actions.colours import BColors
 
@@ -98,7 +98,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
 
         unzip_dir = self._unpack_play_application(SmArtifactRepoFactory.get_play_app_extension(binaryConfig))
         parent, _ = os.path.split(unzip_dir)
-        force_pushdir(parent)
+        force_chdir(parent)
 
         if "frontend" in self.service_data and self.service_data["frontend"]:
            assets_versions = self._get_assets_version(unzip_dir)
@@ -123,7 +123,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
     def _unpack_play_application(self, extension):
         service_data = self.service_data
         microservice_path = self.context.application.workspace + service_data["location"] + "/target/"
-        force_pushdir(microservice_path)
+        force_chdir(microservice_path)
         microservice_filename = service_data["binary"]["artifact"] + extension
 
         unpacked_dir = SmPlayService.unzipped_dir_path(self.context, service_data["location"])
@@ -165,7 +165,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
 
         service_data = self.context.service_data(self.service_name)
         microservice_path = self.context.application.workspace + service_data["location"]
-        curr_dir = force_pushdir(microservice_path)
+        force_chdir(microservice_path)
 
         env_copy = os.environ.copy()
         env_copy["SBT_EXTRA_PARAMS"] = " ".join(sbt_extra_params) # TODO: not needed i think anymore...

--- a/servicemanager/service/smpythonservice.py
+++ b/servicemanager/service/smpythonservice.py
@@ -11,7 +11,7 @@ import requests
 from servicemanager import subprocess
 from smservice import SmService, SmMicroServiceStarter, SmServiceStatus
 from servicemanager.smprocess import SmProcess
-from servicemanager.smfile import force_chdir, force_pushdir, remove_if_exists, remove_folder_if_exists, makedirs_if_not_exists
+from servicemanager.smfile import force_chdir, remove_if_exists, remove_folder_if_exists, makedirs_if_not_exists
 from servicemanager.smnexus import SmNexus
 from servicemanager.smrepo import clone_repo_if_requred
 
@@ -67,7 +67,7 @@ class SmPythonServiceStarter(SmMicroServiceStarter):
         assets_path = self.context.application.workspace + service_data["location"]
 
         cmd_with_params = self.service_data["sources"]["cmd"]
-        force_pushdir(assets_path)
+        force_chdir(assets_path)
         run_from_file = open("RUNNING_FROM", 'w')
         run_from_file.write(self.run_from)
         run_from_file.close()
@@ -92,7 +92,7 @@ class SmPythonServiceStarter(SmMicroServiceStarter):
     def _unzip_assets(self, versions):
         service_data = self.service_data
         assets_zip_path = self.context.get_microservice_target_path(self.service_name)
-        force_pushdir(assets_zip_path)
+        force_chdir(assets_zip_path)
         unzipped_dir = "assets"
         if not os.path.exists(unzipped_dir):
             os.makedirs(unzipped_dir)

--- a/servicemanager/smfile.py
+++ b/servicemanager/smfile.py
@@ -21,9 +21,3 @@ def force_chdir(path):
     makedirs_if_not_exists(path)
     os.chdir(path)
 
-
-def force_pushdir(path):
-    curdir = os.getcwd()
-    makedirs_if_not_exists(path)
-    os.chdir(path)
-    return curdir


### PR DESCRIPTION
…ill fail if inside a directory that is subsequently

deleted during test cleanup.  Results in errors when smserver is used to run services in binary and source mode for example.
None of the callers were using the return value.