### PR TITLE
Fixed issue with nexus packages ocasionally throwing a ZeroDivisionError

### DIFF
--- a/servicemanager/smnexus.py
+++ b/servicemanager/smnexus.py
@@ -31,7 +31,10 @@ class SmNexus():
             return
         duration = time.time() - start_time
         progress_size = int(count * block_size)
-        speed = int(progress_size / (1024 * duration))
+        try:
+            speed = int(progress_size / (1024 * duration))
+        except ZeroDivisionError:
+            speed = 0
         percent = int(count * block_size * 100 / total_size)
         sys.stdout.write("\r%d%%, %d MB, %d KB/s, %d seconds passed" %
                          (percent, progress_size / (1024 * 1024), speed, duration))


### PR DESCRIPTION
Put speed into a try except block in case time.time() - start_time (duration variable) is equal to 0.

This happens rarely but is easily fixed.