### PR TITLE
Prevent calling os.getcwd() from a deleted temp dir

### DIFF
--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -165,7 +165,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
 
         service_data = self.context.service_data(self.service_name)
         microservice_path = self.context.application.workspace + service_data["location"]
-        curr_dir = force_pushdir(microservice_path)
+        force_pushdir(microservice_path)
 
         env_copy = os.environ.copy()
         env_copy["SBT_EXTRA_PARAMS"] = " ".join(sbt_extra_params) # TODO: not needed i think anymore...

--- a/servicemanager/smfile.py
+++ b/servicemanager/smfile.py
@@ -23,7 +23,5 @@ def force_chdir(path):
 
 
 def force_pushdir(path):
-    curdir = os.getcwd()
     makedirs_if_not_exists(path)
     os.chdir(path)
-    return curdir


### PR DESCRIPTION
Running smserver for a Play service from source causes it to fail when pwd context switches to a temp dir. I noticed that the returned old pwd while calling force_pushdir is never used. Removing the code path fixes the ugly runtime exception.