### PR TITLE
Parallelising starting of services in smserver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest==2.5.2
 argcomplete==0.8.1
 pyhamcrest==1.8.3
 mock==1.0.1
+tqdm==4.23.4

--- a/servicemanager/server/smserverlogic.py
+++ b/servicemanager/server/smserverlogic.py
@@ -7,8 +7,8 @@ import sys
 import traceback
 import re
 import types
+import multiprocessing
 
-from multiprocessing import Pool
 from abc import abstractmethod
 from bottle import request, response
 
@@ -209,7 +209,7 @@ class SmStartRequest(SmRequest):
 
     # {"AUTH": {"port": 43124, "runFrom":"JAR", "serviceMapping" : "auth"}}
     def _start_services(self, orchestration_services, service_mapping_ports, proxy):
-        pool = Pool(processes=30)
+        pool = multiprocessing.Pool(processes=30)
         pool.map(ServiceStarter(self.context, deprecated_release_params, service_mapping_ports, proxy), orchestration_services.iteritems())
 
     def _await_service_startup(self, service_name, port, admin_port):

--- a/servicemanager/server/smserverlogic.py
+++ b/servicemanager/server/smserverlogic.py
@@ -32,6 +32,7 @@ class ServiceStarter(object):
 
     def __call__(self, params):
         (service_name, service) = params
+        position = service["position"]
         port = service["port"]
         admin_port = service["adminPort"]
         run_from = service["runFrom"]
@@ -43,7 +44,7 @@ class ServiceStarter(object):
         if run_from in deprecated_release_params:
             run_from = deprecated_release_params[run_from]
 
-        self.context.start_service(service_name, run_from, self.proxy, classifier, self.service_mapping_ports, port, admin_port, version, append_args)
+        self.context.start_service(service_name, run_from, self.proxy, classifier, self.service_mapping_ports, port, admin_port, version, append_args, position)
 
 class BadRequestException(Exception):
     def __init__(self, message):
@@ -209,6 +210,8 @@ class SmStartRequest(SmRequest):
 
     # {"AUTH": {"port": 43124, "runFrom":"JAR", "serviceMapping" : "auth"}}
     def _start_services(self, orchestration_services, service_mapping_ports, proxy):
+        for pos, (k,v) in enumerate(orchestration_services.iteritems(), 0):
+            orchestration_services[k]["position"] = pos
         pool = multiprocessing.Pool(processes=30)
         pool.map(ServiceStarter(self.context, deprecated_release_params, service_mapping_ports, proxy), orchestration_services.iteritems())
 

--- a/servicemanager/server/smserverlogic.py
+++ b/servicemanager/server/smserverlogic.py
@@ -213,7 +213,7 @@ class SmStartRequest(SmRequest):
         for pos, (k,v) in enumerate(orchestration_services.iteritems(), 0):
             orchestration_services[k]["position"] = pos
         pool = multiprocessing.Pool(processes=30)
-        pool.map(ServiceStarter(self.context, deprecated_release_params, service_mapping_ports, proxy), orchestration_services.iteritems())
+        pool.map_async(ServiceStarter(self.context, deprecated_release_params, service_mapping_ports, proxy), orchestration_services.iteritems()).get(9999999)
 
     def _await_service_startup(self, service_name, port, admin_port):
         seconds_remaining = SERVICE_START_TIMEOUT_SECONDS

--- a/servicemanager/server/smserverlogic.py
+++ b/servicemanager/server/smserverlogic.py
@@ -21,6 +21,28 @@ MAX_TEST_ID_LENGTH = 40
 
 deprecated_release_params = {"SNAPSHOT_JAR": "SNAPSHOT", "RELEASE_JAR": "RELEASE"}
 
+class ServiceStarter(object):
+
+    def __init__(self, context, deprecated_release_params, service_mapping_ports,  proxy):
+        self.context = context
+        self.deprecated_release_params = deprecated_release_params
+        self.service_mapping_ports = service_mapping_ports
+        self.proxy = proxy
+
+    def __call__(self, params):
+        (service_name, service) = params
+        port = service["port"]
+        admin_port = service["adminPort"]
+        run_from = service["runFrom"]
+        classifier = service["classifier"]
+        version = service["version"]
+        append_args = service["appendArgs"] # Allows for dynamic config overriding
+
+        # Allow for deprecated run_from values
+        if run_from in deprecated_release_params:
+            run_from = deprecated_release_params[run_from]
+
+        self.context.start_service(service_name, run_from, self.proxy, classifier, self.service_mapping_ports, port, admin_port, version, append_args)
 
 class BadRequestException(Exception):
     def __init__(self, message):
@@ -186,21 +208,8 @@ class SmStartRequest(SmRequest):
 
     # {"AUTH": {"port": 43124, "runFrom":"JAR", "serviceMapping" : "auth"}}
     def _start_services(self, orchestration_services, service_mapping_ports, proxy):
-
-        for service_name in orchestration_services:
-
-            port = orchestration_services[service_name]["port"]
-            admin_port = orchestration_services[service_name]["adminPort"]
-            run_from = orchestration_services[service_name]["runFrom"]
-            classifier = orchestration_services[service_name]["classifier"]
-            version = orchestration_services[service_name]["version"]
-            append_args = orchestration_services[service_name]["appendArgs"] # Allows for dynamic config overriding
-
-            # Allow for deprecated run_from values
-            if run_from in deprecated_release_params:
-                run_from = deprecated_release_params[run_from]
-
-            self.context.start_service(service_name, run_from, proxy, classifier, service_mapping_ports, port, admin_port, version, append_args)
+        pool = Pool(processes=30)
+        pool.map(ServiceStarter(self.context, deprecated_release_params, service_mapping_ports, proxy), orchestration_services.iteritems())
 
     def _await_service_startup(self, service_name, port, admin_port):
         seconds_remaining = SERVICE_START_TIMEOUT_SECONDS

--- a/servicemanager/server/smserverlogic.py
+++ b/servicemanager/server/smserverlogic.py
@@ -8,6 +8,7 @@ import traceback
 import re
 import types
 
+from multiprocessing import Pool
 from abc import abstractmethod
 from bottle import request, response
 

--- a/servicemanager/service/smdropwizardservice.py
+++ b/servicemanager/service/smdropwizardservice.py
@@ -16,10 +16,10 @@ class SmDropwizardServiceStarter(SmJvmServiceStarter):
 
     DEV_NULL = open(os.devnull, 'w')
 
-    def __init__(self, context, service_name, run_from, port, admin_port, classifier, service_mapping_ports, version, proxy, append_args=None):
+    def __init__(self, context, service_name, run_from, port, admin_port, classifier, service_mapping_ports, version, proxy, append_args=None, position=0):
         SmMicroServiceStarter.__init__(self, context, service_name, "dropwizard", run_from, port, classifier, service_mapping_ports, version, proxy, append_args)
-
         self.admin_port = admin_port
+        self.position = position
 
         self.java_options = [
             "-Dfile.encoding=UTF8",
@@ -64,7 +64,7 @@ class SmDropwizardServiceStarter(SmJvmServiceStarter):
 
         if not self.context.offline:
             nexus = SmNexus(self.context, self.service_name)
-            nexus.download_jar_if_necessary(self.run_from, self.version)
+            nexus.download_jar_if_necessary(self.run_from, self.version, self.position)
 
         filename = self._get_jar_filename()
 

--- a/servicemanager/service/smexternalservice.py
+++ b/servicemanager/service/smexternalservice.py
@@ -57,7 +57,7 @@ class SmExternalService(SmService):
         return self.pattern
 
     def stop(self, wait=False):
-        kill_processes_matching(self.pattern, self.context, wait == True, wait)
+        kill_processes_matching(self.pattern, self.context, wait)
 
     def clean_up(self):
         pass

--- a/servicemanager/service/smjvmservice.py
+++ b/servicemanager/service/smjvmservice.py
@@ -15,8 +15,9 @@ class SmJvmServiceStarter(SmMicroServiceStarter):
 
     test_id_param = "service.manager.testId"
 
-    def __init__(self, context, service_name, expected_service_type, run_from, port, classifier, service_mapping_ports, version, proxy, append_args):
+    def __init__(self, context, service_name, expected_service_type, run_from, port, classifier, service_mapping_ports, version, proxy, append_args, position=0):
         SmMicroServiceStarter.__init__(self, context, service_name, expected_service_type, run_from, port, classifier, service_mapping_ports, version, proxy, append_args)
+        self.position = position
 
     def start(self, appendArgs=None):
         if self.run_from == "SOURCE":

--- a/servicemanager/service/smplayservice.py
+++ b/servicemanager/service/smplayservice.py
@@ -67,8 +67,9 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
 
         return extra_params
 
-    def __init__(self, context, service_name, run_from, port, classifier, service_mapping_ports, version, proxy, append_args):
+    def __init__(self, context, service_name, run_from, port, classifier, service_mapping_ports, version, proxy, append_args, position=0):
         SmMicroServiceStarter.__init__(self, context, service_name, "play", run_from, port, classifier, service_mapping_ports, version, proxy, append_args)
+        self.position = position
 
         if not self.port:
             self.port = self.service_data["defaultPort"]
@@ -94,7 +95,7 @@ class SmPlayServiceStarter(SmJvmServiceStarter):
             artifactRepo = SmArtifactRepoFactory.get_repository(self.context, self.service_name, binaryConfig)
             if not self.version:
                 self.version = artifactRepo.find_latest_version(self.run_from, binaryConfig["artifact"], binaryConfig["groupId"])
-            artifactRepo.download_jar_if_necessary(self.run_from, self.version)
+            artifactRepo.download_jar_if_necessary(self.run_from, self.version, self.position)
 
         unzip_dir = self._unpack_play_application(SmArtifactRepoFactory.get_play_app_extension(binaryConfig))
         parent, _ = os.path.split(unzip_dir)

--- a/servicemanager/smbintray.py
+++ b/servicemanager/smbintray.py
@@ -88,7 +88,7 @@ class SmBintray():
             if attempt_count < 5:
               time.sleep(1)
 
-    def download_jar_if_necessary(self, run_from, version):
+    def download_jar_if_necessary(self, run_from, version, position=0):
         artifact = self.context.service_data(self.service_name)["binary"]["artifact"]
         groupId = self.context.service_data(self.service_name)["binary"]["groupId"]
         repo_mappings = self.context.config_value("bintray")["repoMappings"]

--- a/servicemanager/smbintray.py
+++ b/servicemanager/smbintray.py
@@ -8,7 +8,7 @@ import time
 
 from servicemanager.smfile import remove_if_exists
 from actions.colours import BColors
-from smnexus import SmNexus
+from smnexus import SmNexus, TqdmProgress
 from xml.dom.minidom import parse
 
 
@@ -67,14 +67,14 @@ class SmBintray():
             version = self._get_version_info_from_bintray(artifact, repo_mappings[run_from], groupId)
         return version
 
-    def _download_from_bintray(self, bintray_path, local_filename, repositoryId, show_progress):
+    def _download_from_bintray(self, bintray_path, local_filename, repositoryId, show_progress, position=0):
         url = self.context.config_value("bintray")["protocol"] + "://" + self.context.config_value("bintray")["host"] + "/" + repositoryId + "/" + bintray_path
         self.context.log("Attempting to download artefact from Bintray at %s" % url)
         for attempt_count in range(1, 6):
           try:
             if show_progress:
-              urllib.urlretrieve(url, local_filename, SmNexus.report_hook)
-              print("\n")
+                with TqdmProgress(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=local_filename, position=position) as t:
+                    urllib.urlretrieve(url, local_filename, t.report_hook)
             else:
               urllib.urlretrieve(url, local_filename)
             break
@@ -107,7 +107,7 @@ class SmBintray():
             downloaded_md5_path = microservice_target_path + localFilename + ".md5"
 
              # first download the md5 file in order to determine if new artifact download is required
-            self._download_from_bintray(bintrayMD5FilePath, downloaded_md5_path, repositoryId, False)
+            self._download_from_bintray(bintrayMD5FilePath, downloaded_md5_path, repositoryId, False, position)
 
             bintray_md5 = open(downloaded_md5_path, 'r').read()
             local_md5 = SmNexus._md5_if_exists(downloaded_artifact_path)

--- a/servicemanager/smbintray.py
+++ b/servicemanager/smbintray.py
@@ -73,7 +73,7 @@ class SmBintray():
         for attempt_count in range(1, 6):
           try:
             if show_progress:
-              urllib.urlretrieve(url, local_filename, SmNexus._report_hook)
+              urllib.urlretrieve(url, local_filename, SmNexus.report_hook)
               print("\n")
             else:
               urllib.urlretrieve(url, local_filename)

--- a/servicemanager/smcontext.py
+++ b/servicemanager/smcontext.py
@@ -328,7 +328,7 @@ class SmContext():
 
         return original_runfrom
 
-    def get_service_starter(self, service_name, run_from, proxy, classifier=None, service_mapping_ports=None, port=None, admin_port=None, version=None, append_args=None):
+    def get_service_starter(self, service_name, run_from, proxy, classifier=None, service_mapping_ports=None, port=None, admin_port=None, version=None, append_args=None, position=0):
         service = self.get_service(service_name)
         run_from = self.get_run_from_service_override_value_or_use_default(service, run_from)
 
@@ -346,7 +346,7 @@ class SmContext():
         elif service_type == "dropwizard":
             starter = SmDropwizardServiceStarter(self, service_name, run_from, port, admin_port, classifier, service_mapping_ports, version, proxy, append_args)
         elif service_type == "play":
-            starter = SmPlayServiceStarter(self, service_name, run_from, port, classifier, service_mapping_ports, version, proxy, append_args)
+            starter = SmPlayServiceStarter(self, service_name, run_from, port, classifier, service_mapping_ports, version, proxy, append_args, position)
         elif service_type == "assets":
             proxy = None
             starter = SmPythonServiceStarter(self, service_name, run_from, port, classifier, service_mapping_ports, version, proxy, append_args)
@@ -355,10 +355,10 @@ class SmContext():
 
         return starter
 
-    def start_service(self, service_name, run_from, proxy, classifier=None, service_mapping_ports=None, port=None, admin_port=None, version=None, appendArgs=None):
+    def start_service(self, service_name, run_from, proxy, classifier=None, service_mapping_ports=None, port=None, admin_port=None, version=None, appendArgs=None, position=0):
         feature_string = pretty_print_list(" with feature$s $list enabled", self.features)
         self.log("Starting '%s' from %s%s..." % (service_name, run_from, feature_string))
-        service_starter = self.get_service_starter(service_name, run_from, proxy, classifier, service_mapping_ports, port, admin_port, version, appendArgs)
+        service_starter = self.get_service_starter(service_name, run_from, proxy, classifier, service_mapping_ports, port, admin_port, version, appendArgs, position)
         service_process_id = service_starter.start()
 
         if service_process_id:

--- a/servicemanager/smnexus.py
+++ b/servicemanager/smnexus.py
@@ -6,6 +6,7 @@ import hashlib
 import urllib2
 import base64
 from xml.dom.minidom import parse
+from tqdm import tqdm
 
 import requests
 
@@ -15,6 +16,19 @@ from actions.colours import BColors
 
 b = BColors()
 
+class TqdmProgress(tqdm):
+    def report_hook(self, b=1, bsize=1, tsize=None):
+        """
+        b  : int, optional
+            Number of blocks transferred so far [default: 1].
+        bsize  : int, optional
+            Size of each block (in tqdm units) [default: 1].
+        tsize  : int, optional
+            Total size (in tqdm units). If [default: None] remains unchanged.
+        """
+        if tsize is not None:
+            self.total = tsize
+        self.update(b * bsize - self.n)  # will also set self.n = b * bsize
 
 class SmNexus():
 
@@ -22,31 +36,6 @@ class SmNexus():
         self.context = context
         self.service_name = service_name
         self.service_type = context.service_type(service_name)
-
-    @staticmethod
-    def _report_hook(count, block_size, total_size):
-        global start_time
-        global last_update
-
-        current_milli_time = lambda: int(time.time() * 1000)
-
-        if count == 0:
-            start_time = time.time()
-            last_update = current_milli_time()
-            return
-        duration = time.time() - start_time
-        progress_size = int(count * block_size)
-        try:
-            speed = int(progress_size / (1024 * duration))
-        except ZeroDivisionError:
-            speed = 0
-
-        percent = int(count * block_size * 100 / total_size)
-        if percent == 100 or (current_milli_time()  - last_update) > 500:
-            sys.stdout.write("\r%d%%, %d MB, %d KB/s, %d seconds passed" %
-                         (percent, progress_size / (1024 * 1024), speed, duration))
-            sys.stdout.flush()
-            last_update = current_milli_time()
 
     def _create_nexus_extension(self):
         if self.service_type == "play":
@@ -75,11 +64,11 @@ class SmNexus():
         credentials = self.resolve_credentials()
         return urllib.quote_plus(credentials['user']) + ":" + urllib.quote_plus(credentials["password"])
 
-    def _download_from_nexus(self, nexus_path, shaded_jar, show_progress):
+    def _download_from_nexus(self, nexus_path, shaded_jar, show_progress, position=0):
         url = self._get_protocol() + "://" + self._url_credentials() + "@" + nexus_path
         if show_progress:
-            urllib.urlretrieve(url, shaded_jar, SmNexus._report_hook)
-            print("\n")
+            with TqdmProgress(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=shaded_jar, position=position) as t:    
+                urllib.urlretrieve(url, shaded_jar, t.report_hook)
         else:
             urllib.urlretrieve(url, shaded_jar)
 
@@ -160,7 +149,7 @@ class SmNexus():
         versions = self._find_all_versions_in_dom(repository, dom)
         return versions
 
-    def download_jar_if_necessary(self, run_from, version):
+    def download_jar_if_necessary(self, run_from, version, position=0):
         binary = self.context.service_data(self.service_name)["binary"]
         nexus_host = self.context.application.nexus_repo_host
         artifact = binary["artifact"]
@@ -189,12 +178,12 @@ class SmNexus():
                 if self._md5_if_exists(microservice_target_path + nexus_filename) != open(microservice_target_path + md5_filename, 'r').read():
                     remove_if_exists(microservice_target_path + filename)
                     self.context.log("Downloading Nexus binary for '" + self.service_name + "': " + nexus_filename)
-                    self._download_from_nexus(nexus_url + nexus_filename, nexus_filename, self.context.show_progress)
+                    self._download_from_nexus(nexus_url + nexus_filename, nexus_filename, self.context.show_progress, position)
             else:
                 if self._md5_if_exists(microservice_target_path + filename) != open(microservice_target_path + md5_filename, 'r').read():
                     remove_if_exists(microservice_target_path + filename)
                     self.context.log("Downloading Nexus binary for '" + self.service_name + "': " + nexus_filename)
-                    self._download_from_nexus(nexus_url + nexus_filename, filename, self.context.show_progress)
+                    self._download_from_nexus(nexus_url + nexus_filename, filename, self.context.show_progress, position)
             os.remove(microservice_target_path + md5_filename)
         else:
             print b.warning + "WARNING: Due to lack of version data from nexus you may not have an up to date version..." + b.endc

--- a/servicemanager/smnexus.py
+++ b/servicemanager/smnexus.py
@@ -67,7 +67,7 @@ class SmNexus():
     def _download_from_nexus(self, nexus_path, shaded_jar, show_progress, position=0):
         url = self._get_protocol() + "://" + self._url_credentials() + "@" + nexus_path
         if show_progress:
-            with TqdmProgress(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=shaded_jar, position=position) as t:    
+            with TqdmProgress(unit='B', unit_scale=True, unit_divisor=1024, miniters=1, desc=shaded_jar, position=position) as t:
                 urllib.urlretrieve(url, shaded_jar, t.report_hook)
         else:
             urllib.urlretrieve(url, shaded_jar)

--- a/servicemanager/smprocess.py
+++ b/servicemanager/smprocess.py
@@ -7,17 +7,15 @@ import time
 from servicemanager import subprocess
 
 
-def kill_pid(context, pid, force=False, wait=False):
+def kill_pid(context, pid, wait=False):
 
     if _is_system_or_smserver_or_test_process(pid):
         return "Not allowed to kill system, test or smserver process (pid = %d)" % pid
 
     try:
         print("killing pid: " + str(pid))
-        if force:
-            os.kill(pid, SIGKILL)
-        else:
-            os.kill(pid, SIGINT)
+
+        os.kill(pid, SIGKILL)
 
         if wait:
             os.waitpid(pid, 0)
@@ -28,12 +26,12 @@ def kill_pid(context, pid, force=False, wait=False):
         return error
 
 
-def kill_processes_matching(pattern, context, force=False, wait=False):
+def kill_processes_matching(pattern, context, wait=False):
 
     # Be polite and ask the processes to quit
     processes = SmProcess.processes_matching(pattern)
     for process in processes:
-        kill_pid(context, process.pid, False, False)
+        kill_pid(context, process.pid, False)
 
     waited = 0.0
     time_between_polls = 0.1
@@ -46,9 +44,8 @@ def kill_processes_matching(pattern, context, force=False, wait=False):
         time.sleep(time_between_polls)
         waited = waited + time_between_polls
 
-    if force:
-        for process in processes:
-                kill_pid(context, process.pid, force, wait)
+    for process in processes:
+        kill_pid(context, process.pid, wait)
 
 def _is_system_or_smserver_or_test_process(pid):
 


### PR DESCRIPTION
Our integration tests are failing in ci-dev due to the services taking too long to spin up. This fixes the issue and speeds up the process drastically. 