### PR TITLE
Allow later patch versions of argcomplete

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="servicemanager",
-    version="2.0.6",
+    version="2.0.7",
     description="A python tool to manage developing and testing with lots of microservices",
     url="https://github.com/hmrc/service-manager",
     author="hmrc-web-operations",
@@ -20,7 +20,7 @@ setup(
         "bottle==0.12.18",
         "pytest==5.4.3",
         "pyhamcrest==2.0.2",
-        "argcomplete==1.12.0",
+        "argcomplete~=1.12.0",
         "prettytable==0.7.2"
     ],
     scripts=["bin/sm", "bin/smserver"],


### PR DESCRIPTION
Using ~ should install 1.12.1 if available (which it is)

Specifically, we want the changes here:
https://github.com/kislyuk/argcomplete/issues/321

importlib-metadata 2.0 was released, and argcomplete defined that 2.0
should never be use that version, until the most recent current version.

I believe that one of our test dependencies imported a higher version of
argcomplete before the resolver realised this. There is potentially
another piece of work to NOT install test dependencies for users of
servicemanager, but that can be postponed for now.