### PR TITLE
BDOG-1021: merge pytest.ini into tox.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-# see https://docs.pytest.org/en/latest/mark.html
-
-[pytest]
-markers =
-    online: marks tests that download large repositories (skip via '-m "not online"')

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,5 @@ commands =
 addopts = --junitxml=target/report.xml
           --fulltrace
 testpaths = test
+markers =
+    online: marks tests that download large repositories (skip via '-m "not online"')


### PR DESCRIPTION
In order to reduce warnings I had explicitly defined pytest markers, and following pytest documentation put this in `pytest.ini`.
I had not realised that some pytest config already existed in `tox.ini`.  This now seems to be ignored, with the result that Jenkins builds fail because a junit report is not generated.

Revert the addition of `pytest.ini`, and instead add the pytest marker config into the existing `tox.ini`.